### PR TITLE
moved postgres DB credentials to .env file addressing issue #67

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+POSTGRES_USER=timescaledb
+POSTGRES_PASSWORD=postgrespassword

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Copy .env.example to .env
+        run: cp .env.example .env
+
       - name: Run DBs
         # working-directory: .
         run: docker-compose up -d
@@ -35,7 +38,7 @@ jobs:
         working-directory: impl/c-qube
         run: |
           touch .env
-          echo "DATABASE_URL="postgres://timescaledb:postgrespassword@localhost:5432/postgres?sslmode=disable"" > .env
+          echo "DATABASE_URL"="postgres://timescaledb:postgrespassword@localhost:5432/postgres?sslmode=disable" >> .env
 
       - name: Install dependencies
         working-directory: impl/c-qube

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,33 +7,32 @@ services:
     image: timescale/timescaledb:2.0.0-pg12
     restart: always
     ports:
-      - "5432:5432"
+      - '5432:5432'
     volumes:
       - ./pgdata:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: timescaledb
-      POSTGRES_PASSWORD: postgrespassword
+    env_file:
+      - .env
 
   graphql-engine:
     image: hasura/graphql-engine:latest
     ports:
-      - "8080:8080"
+      - '8080:8080'
     volumes:
       - ./data/migrations:/hasura-migrations
       - ./data/metadata:/hasura-metadata
     depends_on:
-      - "timescaledb"
+      - 'timescaledb'
     restart: always
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://timescaledb:postgrespassword@timescaledb:5432/postgres?sslmode=disable
       ## enable the console served by server
-      HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
+      HASURA_GRAPHQL_ENABLE_CONSOLE: 'true' # set to "false" to disable console
       ## enable debugging mode. It is recommended to disable this in production
-      HASURA_GRAPHQL_DEV_MODE: "true"
+      HASURA_GRAPHQL_DEV_MODE: 'true'
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup,http-log,webhook-log,websocket-log,query-log
       ## uncomment next line to set an admin secret
       # HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
-      HASURA_GRAPHQL_MIGRATIONS_DISABLE_TRANSACTION: "true"
+      HASURA_GRAPHQL_MIGRATIONS_DISABLE_TRANSACTION: 'true'
       HASURA_GRAPHQL_CONSOLE_ASSETS_DIR: /srv/console-assets
 
   pgpool-serv:


### PR DESCRIPTION
Address the issue #67 

1. Moved out the sensitive information like DB username & password to a .env file
2. Added a .env.example file to copy the credentials from when setting up locally

Additional Todos,
- [ ] update onboarding documentation asking the user to create a .env file & copying the creds from .env.example