### PR TITLE
feat: implement whitelist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ venv
 scratchpad.md
 .env
 random_data.csv
+
+ingest
+ingest-bak
+ingest-new

--- a/impl/c-qube/src/prisma.service.ts
+++ b/impl/c-qube/src/prisma.service.ts
@@ -8,7 +8,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   }
 
   async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
+    this.$on('beforeExit' as unknown as never, async () => {
       await app.close();
     });
   }

--- a/impl/c-qube/src/services/csv-adapter/csv-adapter.service.ts
+++ b/impl/c-qube/src/services/csv-adapter/csv-adapter.service.ts
@@ -185,14 +185,15 @@ export class CsvAdapterService {
     s.start('🚧 4. Processing Event Grammars');
     const eventGrammarsGlobal: EventGrammar[] = [];
     for (let j = 0; j < config?.programs.length; j++) {
-      const inputFiles = readdirSync(config?.programs[j].input?.files);
+      const inputFiles = readdirSync(config?.programs[j].input?.files); // read the data files
       // For 1TimeDimension + 1EventCounter + 1Dimension
+      // Looping through the data files for the program
       for (let i = 0; i < inputFiles?.length; i++) {
         if (regexEventGrammar.test(inputFiles[i])) {
-          // console.log(config?.programs[j].input?.files + `/${inputFiles[i]}`);
+          // check if the filename is as per the standard
           const eventGrammarFileName =
             config?.programs[j].input?.files + `/${inputFiles[i]}`;
-          // console.log(eventGrammarFileName);
+          // check if there is a time-dimension in the current data file
           const ifTimeDimensionPresent = await isTimeDimensionPresent(
             eventGrammarFileName,
           );
@@ -200,6 +201,9 @@ export class CsvAdapterService {
             eventGrammarFileName,
             dimensionGrammarFolder,
             config?.programs[j].namespace,
+            config?.programs[j].onlyCreateWhitelisted
+              ? config?.programs[j].dimensions.whitelisted.single
+              : ['*'],
           );
           eventGrammarsGlobal.push(...eventGrammar);
           for (let i = 0; i < eventGrammar.length; i++) {
@@ -224,6 +228,8 @@ export class CsvAdapterService {
             );
             datasetGrammarsGlobal.push(...dgs2);
           }
+        } else {
+          // TODO: add this file name to a error log file and show at the end
         }
       }
     }
@@ -240,7 +246,7 @@ export class CsvAdapterService {
       const inputFiles = readdirSync(config?.programs[j].input?.files);
       for (let i = 0; i < inputFiles?.length; i++) {
         const compoundDimensions: string[] =
-          config.programs[j].dimensions.whitelisted;
+          config.programs[j].dimensions.whitelisted.compound;
         for (let k = 0; k < compoundDimensions.length; k++) {
           const eventGrammarFiles = [];
           const compoundDimensionsToBeInEG = compoundDimensions[k]
@@ -384,6 +390,7 @@ export class CsvAdapterService {
 
     // Create Empty Dataset Tables
     for (let i = 0; i < datasetGrammarsGlobal.length; i++) {
+      // console.log('datasetGrammarsGlobal[i]: ', datasetGrammarsGlobal[i]);
       await this.datasetService.createDataset(datasetGrammarsGlobal[i]);
     }
 

--- a/impl/c-qube/src/services/csv-adapter/parser/event-grammar/event-grammar.helpers.ts
+++ b/impl/c-qube/src/services/csv-adapter/parser/event-grammar/event-grammar.helpers.ts
@@ -98,6 +98,7 @@ export const processCSVtoEventGrammarDefJSON = (
   fieldDataType: string,
   fieldName: string,
   fieldType: string,
+  singleDimensionWhitelist?: string[],
 ): EventGrammarCSVFormat[] => {
   // Vertical columns for CSV File
   // | dimensionName |
@@ -105,21 +106,27 @@ export const processCSVtoEventGrammarDefJSON = (
   // | fieldDataType |
   // | fieldName |
   // | fieldType |
-  return fieldType.split(',').map((value, index) => {
-    return {
-      dimensionName:
-        dimensionName.split(',')[index].trim() === ''
-          ? null
-          : dimensionName.split(',')[index].trim(),
-      dimensionGrammarKey:
-        dimensionGrammarKey.split(',')[index].trim() === ''
-          ? null
-          : dimensionGrammarKey.split(',')[index].trim(),
-      fieldDataType: fieldDataType.split(',')[index].trim() as ColumnType,
-      fieldName: fieldName.split(',')[index].trim(),
-      fieldType: fieldType.split(',')[index].trim() as FieldType,
-    };
-  });
+  return fieldType
+    .split(',')
+    .map((value, index) => {
+      return {
+        dimensionName:
+          dimensionName.split(',')[index].trim() === ''
+            ? null
+            : dimensionName.split(',')[index].trim(),
+        dimensionGrammarKey:
+          dimensionGrammarKey.split(',')[index].trim() === ''
+            ? null
+            : dimensionGrammarKey.split(',')[index].trim(),
+        fieldDataType: fieldDataType.split(',')[index].trim() as ColumnType,
+        fieldName: fieldName.split(',')[index].trim(),
+        fieldType: fieldType.split(',')[index].trim() as FieldType,
+      };
+    })
+    .filter((item) => {
+      if (!singleDimensionWhitelist) return true;
+      return singleDimensionWhitelist.includes(item.dimensionName);
+    });
 };
 
 export const getInstrumentField = (


### PR DESCRIPTION
## Description

This PR extends the functionality of whitelisting to enable the user to specify only the dimensions they want to be considered/respected while creating datasets.

This PR also introduces a change in the `config.json` structure which might break existing usecases.

The change is outlined as followed,
Presently the `whitelisted` field in the object of a program is an array (refer below)
```json
...
"dimensions": {
        "whitelisted": {
          "single": [],
          "compound": [
            "state,grade,subject,medium,board",
            "textbookdiksha,grade,subject,medium",
            "textbookdiksha,grade,subject,medium"
          ]
        },
        "blacklisted": []
      }
...
```

this object has been updated to look something like,

```json
...
"dimensions": {
        "whitelisted": {
          "single": ["medium"],
          "compound": [
            "state,grade,subject,medium,board",
            "textbookdiksha,grade,subject,medium",
            "textbookdiksha,grade,subject,medium"
          ]
        },
        "blacklisted": []
      }
...

```

basically the whitelist object has been changed to an object having two properties, `single` and `compound` for a clearer definition of dimensions.
Apart from this, the PR also _assumes_ that the user is going to fill in the final `dimensionName` and NOT the `fieldName` in the dimension arrays, this assumption was based on the current sample `config.json` which uses the term `textbookdiksha` and not `textbook_id`. The support for doing an either/or between the `dimensionName` and `fieldName` can be provided as per discussions.


### Future Scope

- [ ] Providing the functionality to toggle between `dimensionName` and `fieldName` while specifying dimensions in whitelist
- [ ] A way to specify event names in combination with dimensions (both single and compound) so that the user has more control over the tables being created